### PR TITLE
support tab-completed file paths for module discovery

### DIFF
--- a/test/test_discovery_test.py
+++ b/test/test_discovery_test.py
@@ -2,7 +2,7 @@ from testify import TestCase, run, test_discovery
 
 class DiscoveryTestCase(TestCase):
     def discover(self, path):
-        # Exhause the generator to catch exceptons
+        # Exhaust the generator to catch exceptons
         [mod for mod in test_discovery.discover(path)]
 
 class TestDiscoverDottedPath(DiscoveryTestCase):

--- a/testify/test_discovery.py
+++ b/testify/test_discovery.py
@@ -52,7 +52,7 @@ def discover(what):
         suites = suites or []
         if isinstance(locator, basestring):
             # Transform file paths into dotted import paths
-            locator = locator.replace('/', '.')
+            locator = locator.replace(os.sep, '.')
             if locator.endswith('.py'):
                 locator = locator.rstrip('.py')
 


### PR DESCRIPTION
Slashes used to work on my old dev box but not my new one, so I threw this together real quick to fix it. The corresponding issue is #14. Also makes testify more friendly to tab completion by not freaking out over a '.py' suffix, e.g., this now works:

testify yelp/tests/component/business_match_test.py BusinessMatchTest
