### PR TITLE
Two new options for profiling and random seed.

### DIFF
--- a/testify/test_program.py
+++ b/testify/test_program.py
@@ -54,6 +54,7 @@ def parse_test_runner_command_line_args(args):
     parser.add_option("-v", "--verbose", action="store_const", const=VERBOSITY_VERBOSE, dest="verbosity")
 
     parser.add_option("-c", "--coverage", action="store_true", dest="coverage")
+    parser.add_option("-p", "--profile", action="store_true", dest="profile")
 
     parser.add_option("-i", "--include-suite", action="append", dest="suites_include", type="string", default=[])
     parser.add_option("-x", "--exclude-suite", action="append", dest="suites_exclude", type="string", default=[])
@@ -89,6 +90,7 @@ def parse_test_runner_command_line_args(args):
         'suites_include': options.suites_include,
         'suites_exclude': options.suites_exclude,
         'coverage': options.coverage,
+        'profile': options.profile,
         'module_method_overrides': module_method_overrides,
         'summary_mode': options.summary_mode,
         'test_logger_class': (TextTestLogger if not options.disable_color else ColorlessTextTestLogger)

--- a/testify/test_runner.py
+++ b/testify/test_runner.py
@@ -28,6 +28,7 @@ import traceback
 import types
 
 import code_coverage
+import cProfile
 from test_case import MetaTestCase, TestCase
 import test_discovery
 from test_logger import _log, TextTestLogger, VERBOSITY_SILENT, VERBOSITY_NORMAL, VERBOSITY_VERBOSE
@@ -44,6 +45,7 @@ class TestRunner(object):
         suites_include=[],
         suites_exclude=[],
         coverage=False,
+        profile=False,
         summary_mode=False,
         test_logger_class=TextTestLogger,
         module_method_overrides={}):
@@ -54,6 +56,7 @@ class TestRunner(object):
         self.suites_exclude = set(suites_exclude)
 
         self.coverage = coverage
+        self.profile = profile
         self.logger = test_logger_class(self.verbosity)
         self.summary_mode = summary_mode
 
@@ -133,7 +136,11 @@ class TestRunner(object):
                     code_coverage.start(test_case.__class__.__module__ + "." + test_case.__class__.__name__)
                     
                 # callbacks registered, this will actually run the TestCase's fixture and test methods
-                test_case.run()
+                if self.profile:
+                    cprofile_filename = test_case.__class__.__module__ + "." + test_case.__class__.__name__ + '.cprofile'
+                    cProfile.runctx('test_case.run()', globals(), locals(), cprofile_filename)
+                else:
+                    test_case.run()
                 
                 # Stop tracking and save the coverage info
                 if self.coverage:


### PR DESCRIPTION
-p for running test each test inside cProfile context.

--seed for setting random seed before each test. Each test is seeded with the given number + a hash of the test case. That was test runs can have random numbers, yet each run (each test even) can be reproducible.

Eg. buildbot will pass --seed <time> to testify. Now if a test fails/flakes, at least we can rerun with the same --seed value, and know we should get the same sequence of random numbers. 
