### PR TITLE
add a descriptive error message when no tests are discovered

### DIFF
--- a/testify/test_logger.py
+++ b/testify/test_logger.py
@@ -227,7 +227,7 @@ class TextTestLogger(TestLoggerBase):
                 status_string = self._colorize("PASSED", self.GREEN)
             else:
                 if test_method_count == 0:
-                    self.writeln("No tests were discovered (no methods starting with 'test'?).")
+                    self.writeln("No tests were discovered (tests must subclass TestCase and test methods must begin with 'test').")
                 status_string = self._colorize("ERROR", self.MAGENTA)
         else:
             status_string = self._colorize("FAILED", self.RED)


### PR DESCRIPTION
e.g.,

shivaram@dev16:~/pg/Testify (warning) $ bin/testify test.json_log_test

No tests were discovered (no methods starting with 'test'?).
ERROR.  0 tests / 0 cases: 0 passed, 0 failed.  (Total test time 0.00s
