### PR TITLE
Don't shut down so immediately even if all the runners have come back…

### DIFF
--- a/test/test_runner_server_test.py
+++ b/test/test_runner_server_test.py
@@ -47,7 +47,7 @@ class TestRunnerServerTestCase(test_case.TestCase):
                 runner_timeout=1,
                 server_timeout=10,
                 revision=None,
-                shutdown_delay_for_connection_close=1,
+                shutdown_delay_for_connection_close=0.001,
                 shutdown_delay_for_outstanding_runners=1,
             ),
             serve_port=0,

--- a/testify/test_program.py
+++ b/testify/test_program.py
@@ -133,7 +133,7 @@ def parse_test_runner_command_line_args(plugin_modules, args):
     parser.add_option('--runner-timeout', action="store", dest="runner_timeout", type="int", default=300, help="How long to wait to wait for activity from a test runner before requeuing the tests it has checked out.")
     parser.add_option('--server-timeout', action="store", dest="server_timeout", type="int", default=300, help="How long to wait after the last activity from any test runner before shutting down.")
 
-    parser.add_option('--server-shutdown-delay', action='store', dest='shutdown_delay_for_connection_close', type="int", default=10, help="How long to wait (in milliseconds) for data to finish writing to sockets before shutting down the server.")
+    parser.add_option('--server-shutdown-delay', action='store', dest='shutdown_delay_for_connection_close', type="float", default=0.01, help="How long to wait (in seconds) for data to finish writing to sockets before shutting down the server.")
     parser.add_option('--server-shutdown-delay-outstanding-runners', action='store', dest='shutdown_delay_for_outstanding_runners', type='int', default=5, help="How long to wait (in seconds) for all clients to check for new tests before shutting down the server.")
 
     parser.add_option('--runner-id', action="store", dest="runner_id", type="string", default="%s-%d" % (socket.gethostname(), os.getpid()), help="With --connect, an identity passed to the server on each request. Passed to the server's test reporters. Defaults to <HOST>-<PID>.")

--- a/testify/test_runner_server.py
+++ b/testify/test_runner_server.py
@@ -386,4 +386,4 @@ class TestRunnerServer(TestRunner):
             iol.add_timeout(time.time()+self.shutdown_delay_for_outstanding_runners, iol.stop)
         else:
             # Give tornado enough time to finish writing to all the clients, then shut down.
-            iol.add_timeout(time.time()+self.shutdown_delay_for_connection_close/1000.0, iol.stop)
+            iol.add_timeout(time.time()+self.shutdown_delay_for_connection_close, iol.stop)


### PR DESCRIPTION
because sometimes our response hasn't actually been written to the socket. Also make the server shutdown timeouts configurable.
