### PR TITLE
Add let().

### DIFF
--- a/test/test_case_test.py
+++ b/test/test_case_test.py
@@ -1,8 +1,11 @@
+import itertools
+
 from testify import TestCase
 from testify import assert_equal
 from testify import class_setup
 from testify import class_setup_teardown
 from testify import class_teardown
+from testify import let
 from testify import run
 from testify import setup
 from testify import setup_teardown
@@ -244,6 +247,31 @@ class OverrideTest(TestCase):
 
     def test_method_2(self):
         pass
+
+class LetTest(TestCase):
+
+    @let
+    def counter(self):
+        return itertools.count(0)
+
+    def test_first_call_is_not_cached(self):
+        assert_equal(self.counter.next(), 0)
+
+    def test_subsequent_calls_are_cached(self):
+        assert_equal(self.counter.next(), 0)
+        assert_equal(self.counter.next(), 1)
+
+class LetWithLambdaTest(TestCase):
+
+    counter = let(lambda self: itertools.count(0))
+
+    def test_first_call_is_not_cached(self):
+        assert_equal(self.counter.next(), 0)
+
+    def test_subsequent_calls_are_cached(self):
+        assert_equal(self.counter.next(), 0)
+        assert_equal(self.counter.next(), 1)
+
 
 if __name__ == '__main__':
     run()

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -42,7 +42,8 @@ from test_case import (
                         class_teardown,
                         setup_teardown,
                         class_setup_teardown,
-                        suite)
+                        suite,
+                        let)
 
 from utils import turtle
 


### PR DESCRIPTION
A decorator enabling lazily evaluated test helpers. This feature is useful for cleaning up tests.

Before:

``` python
class MyTest(TestCase):

    @setup
    def create_user(self):
        self.user = create_user()

    @setup
    def create_business(self):
        self.business = create_business()

    def test_with_user(self):
        assert self.user

    def test_with_user_and_business(self):
        assert self.user and self.business
```

There's waste in `test_with_user()` because it doesn't use `business`.

After:

``` python
class MyTest(TestCase):

    @let
    def user(self):
        return create_user()

    business = let(lambda self: create_business())

    def test_with_user(self):
        assert self.user

    def test_with_user_and_business(self):
        assert self.user and self.business
```

`user` or `business` are evaluated once per test and saved for subsequent calls. `let()` is essentially `cached_property()` except it's reset before each test.

I think the Rubyist in me mostly prefers the terser syntax with the lambda. Both make me very happy, though.

Stolen from [RSpec](https://www.relishapp.com/rspec/rspec-core/docs/helper-methods/let-and-let) (even [their tests](https://github.com/rspec/rspec-core/blob/master/spec/rspec/core/let_spec.rb)).
