### PR TITLE
Better interface to Turtle calls 

### DIFF
--- a/testify/utils/turtle.py
+++ b/testify/utils/turtle.py
@@ -64,6 +64,9 @@ class Turtle(object):
     def __len__(self):
         return len(self.calls)
 
+    def __nonzero__(self):
+        return True
+
     def __getattr__(self, name):
         self.__dict__[name] = Turtle()
         return self.__dict__[name]


### PR DESCRIPTION
Gives access to turtle calls by making them iterable.

```
for args, kwargs in t:
     print args, kwargs
```

If you're using this object as a stand in for something that's normally iterable (like a list or dict) then it should just run fine iterating 0 times. If you're using this as a callable then you have a convenient new API. Seems unlikely that anyone would be doing both.

This has the side effect of making turtle objects not fail in some additional scenarios like:

```
if 'k' in t:
    print blah

for k in t:
    do_stuff()

if len(k) > 0:
     print k[1]
```

I think it's more useful this way and shouldn't have any negative consequences.

Also fixed up the examples in the documentation that were oddly inconsistent.
