### PR TITLE
Added new option to testify to go into post mortem debugging mode when exception is raised.

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -148,7 +148,7 @@ class TestCase(object):
         self.__suites_require = kwargs.get('suites_require', set())
         self.__name_overrides = kwargs.get('name_overrides', None)
 
-        self.__debugger = kwargs.get('debugger', False)
+        self.__debugger = kwargs.get('debugger')
 
         # callbacks for various stages of execution, used for stuff like logging
         self.__callbacks = defaultdict(list)

--- a/testify/test_result.py
+++ b/testify/test_result.py
@@ -78,6 +78,7 @@ class TestResult(object):
             self.interrupted = True
             self.exception_info = exception_info
 
+
     def format_exception_info(self, pretty=False):
         if self.exception_info is None:
             return None

--- a/testify/test_runner.py
+++ b/testify/test_runner.py
@@ -38,7 +38,7 @@ class TestRunner(object):
                  bucket_count=None,
                  bucket_overrides=None,
                  bucket_salt=None,
-                 debugger=False,
+                 debugger=None,
                  suites_include=(),
                  suites_exclude=(),
                  suites_require=(),
@@ -93,7 +93,7 @@ class TestRunner(object):
                             suites_require=self.suites_require,
                             name_overrides=self.module_method_overrides.get(test_case_class.__name__, None),
                             failure_limit=(self.failure_limit - self.failure_count) if self.failure_limit else None,
-                            debugger=self.debugger
+                            debugger=self.debugger,
                         )
                         yield test_case
 


### PR DESCRIPTION
Hey Testitfiers,

If an exception is raised during any user defined function, testify can throw the tester into a ipdb post_mortem debugging shell to inspect the environment in which the exception was raised.  I thought this feature would be super nifty for avoiding the lengthier process of going to the line number in the code, writing a set trace by hand, and then re-running the test suite.  It was pretty easy to add.  Hard to test automatically unfortunately because the external programmable behavior of testify is identical to it without the feature.  I can throw a file which demos it on the repo if requested, but the file won't assert the feature's correctness.  Any ideas for an automatic test?

Decided not to go the plugin route because it would require preparing each test_case object by wrapping all the user defined functions in the class.  This is non-trivial because of test case inheritance, dynamically defined method names, etc...  Way more complex code => more bugs.

I tried making it flexible in usage of pdb if ipdb didn't exist, but I kept running into some very strange behavior where code was disappearing during post mortem debugging.  I'm not sure what that's all about, so I didn't implement this.  Nevertheless, a strict dependency on ipdb is okay, temporarily.
