### PR TITLE
make TestLogger write to stderr instead of stdout

### DIFF
--- a/testify/test_logger.py
+++ b/testify/test_logger.py
@@ -115,7 +115,7 @@ class TestLoggerBase(test_reporter.TestReporter):
             return "%s.%s" % (test_method['class'], test_method['name'])
 
 class TextTestLogger(TestLoggerBase):
-    def __init__(self, options, stream=sys.stdout):
+    def __init__(self, options, stream=sys.stderr):
         super(TextTestLogger, self).__init__(options, stream)
 
         # Checking for color support isn't as fun as we might hope.  We're


### PR DESCRIPTION
Maybe there's a reason it isn't like this already?

Anyway, the primary motivation was to have discovery failure messages appear on stderr, but this seems generally relevant.
