### PR TITLE
let decorator shouldn't try to execute unbounded methods.

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -641,6 +641,9 @@ class let(object):
     def __get__(self, test_case, cls):
         if test_case is None:
             return self
+        if not hasattr(self._func, "im_self") or self._func.im_self is None:
+            # Should not try to execute unbounded method
+            return self
         if self._result is self._unsaved:
             self._save_result(self._func(test_case))
             self._register_reset_after_test_completion(test_case)


### PR DESCRIPTION
calling getattr(TestCaseClass, method_name) tries to execute the method. I believe this is not the intended behavior.
