### PR TITLE
Add length cap for the SQL reporter.

### DIFF
--- a/test/plugins/sql_reporter_test.py
+++ b/test/plugins/sql_reporter_test.py
@@ -12,8 +12,8 @@ except ImportError:
 
 
 from test.discovery_failure_test import BrokenImportTestCase
-from testify import TestCase, setup_teardown, assert_equal, assert_gt, assert_in_range
-from testify.plugins.sql_reporter import SQLReporter, add_command_line_options, Tests, Builds, TestResults, Failures
+from testify import TestCase, assert_equal, assert_gt, assert_in,  assert_in_range, setup_teardown
+from testify.plugins.sql_reporter import Builds, Failures, SQLReporter, TestResults, Tests, add_command_line_options
 from testify.test_result import TestResult
 from testify.test_runner import TestRunner
 
@@ -159,8 +159,8 @@ class SQLReporterTestCase(SQLReporterBaseTestCase):
         result.end_in_failure((type(AssertionError), AssertionError('A' * 200), None))
 
         with patch.object(self.reporter.options, 'sql_traceback_size', 50):
-            with patch.object(result, 'format_exception_info') as format_exception_info:
-                format_exception_info.return_value = ["AssertionError: %s" % ('A' * 200), 'A' * 200]
+            with patch.object(result, 'format_exception_info') as mock_format_exception_info:
+                mock_format_exception_info.return_value = ["AssertionError: %s" % ('A' * 200), 'A' * 200]
 
                 self.reporter.test_complete(result.to_dict())
 
@@ -169,6 +169,8 @@ class SQLReporterTestCase(SQLReporterBaseTestCase):
         failure = conn.execute(Failures.select()).fetchone()
         assert_equal(len(failure.traceback), 50)
         assert_equal(len(failure.error), 50)
+        assert_in('Exception truncated.', failure.traceback)
+        assert_in('Exception truncated.', failure.error)
 
 
 class SQLReporterDiscoveryFailureTestCase(SQLReporterBaseTestCase, BrokenImportTestCase):


### PR DESCRIPTION
If a test generates exceptionally long failure messages or tracebacks, it can cause the SQL server to reject the statement (strict mode, packet length restrictions, etc.). Since we declare Failure.error and Failure.traceback as TEXT types, truncate the data going into them to the size of these columns by default.
