### PR TITLE
Fix the code coverage plugin to work again.

### DIFF
--- a/testify/utils/code_coverage.py
+++ b/testify/utils/code_coverage.py
@@ -33,28 +33,21 @@ try:
 except (ImportError, NameError), ex:
     coverage = None
 
-started = False
 coverage_instance = None
 
 def start(testcase_name = None):
-    global started
     global coverage_instance
-    assert not started
     if coverage is not None:
-        coverage_instance = coverage.coverage(data_file="coverage_file.", data_suffix=testcase_name, auto_data=True)
+        coverage_instance = coverage.coverage(data_file=".coverage", data_suffix=testcase_name, auto_data=True)
     else:
         coverage_instance = FakeCoverage()
 
     coverage_instance.start()
-    started = True
 
 def stop():
-    global started
     global coverage_instance
-    assert started
     coverage_instance.stop()
     coverage_instance.save()
-    started = False
 
 if __name__ == "__main__":
     if coverage is None:


### PR DESCRIPTION
It was crashing with;

```
eskil@dev19:~/pg/somelib (tests) $ PYTHONPATH=. testify --coverage --summary --exclude-suite=disabled --verbose tests
tests.client_test TestPath.test_path ... ok in 0.00s
Traceback (most recent call last):
  File "/usr/bin/testify", line 25, in <module>
    test_program.TestProgram()
  File "/usr/lib/python2.6/dist-packages/testify/test_program.py", line 276, in __init__
    result = runner.run()
  File "/usr/lib/python2.6/dist-packages/testify/test_runner.py", line 157, in run
    runnable()
  File "/usr/lib/python2.6/dist-packages/testify/plugins/seed.py", line 24, in run_test_case
    return runnable()
  File "/usr/lib/python2.6/dist-packages/testify/plugins/code_coverage.py", line 21, in run_test_case
    code_coverage.start(test_case.__class__.__module__ + "." + test_case.__class__.__name__)
  File "/usr/lib/python2.6/dist-packages/testify/utils/code_coverage.py", line 42, in start
    assert not started
AssertionError
```

Not sure what the start=True/False was for, but begone. Also changed the
coverage file name to match what the coverage cli tool expects. Now I can;

```
testify --coverage --summary --exclude-suite=disabled --verbose tests
coverage combine
coverage report -m
...
clientlib/thrifty                96     29    70%
-------------------------------------------------
TOTAL                          3696   2924    21%
```
