### PR TITLE
violation collector: make read fd non-blocking and check for event type when polling

### DIFF
--- a/test/plugins/violation_collector_test.py
+++ b/test/plugins/violation_collector_test.py
@@ -247,7 +247,7 @@ class ViolationReporterTestCase(T.TestCase):
 
 class ViolationStoreTestCase(T.TestCase):
 
-    def test_connect(self):
+    def test_violation_store_does_not_connect_db_when_initialized(self):
         with mocked_store() as mock_store:
             T.assert_equal(mock_store.engine, None)
             T.assert_equal(mock_store.conn, None)


### PR DESCRIPTION
Fixes some of the issues on buildbot. Using a non-blocking fd with edge triggered flag is already suggested in epoll man page (http://linux.die.net/man/4/epoll), apparently I've forgot about that before.
