### PR TITLE
add a unique buildbot run identifier

### DIFF
--- a/test/plugins/sql_reporter_test.py
+++ b/test/plugins/sql_reporter_test.py
@@ -110,11 +110,9 @@ class SQLReporterTestCase(SQLReporterBaseTestCase):
         assert 'discovery_failure' in build
         assert_equal(build['discovery_failure'], False)
 
-        # Check test results and their buildbot_run_ids
+        # Check test results.
         test_results = self._get_test_results(conn)
         assert_equal(len(test_results), 2)
-        for test_result in test_results:
-            assert_equal(test_result['buildbot_run_id'], self.fake_buildbot_run_id)
 
         # Check that we have one failure and one pass, and that they're the right tests.
         (passed_test,) = [r for r in test_results if not r['failure']]

--- a/testify/plugins/sql_reporter.py
+++ b/testify/plugins/sql_reporter.py
@@ -59,7 +59,6 @@ class SQLReporter(test_reporter.TestReporter):
         
         build_info_dict = json.loads(options.build_info)
         self.build_id = self.create_build_row(build_info_dict)
-        self.buildbot_run_id = build_info_dict['buildbot_run_id']
         self.start_time = time.time()
 
         # Cache of (module,class_name,method_name) => test id
@@ -119,7 +118,6 @@ class SQLReporter(test_reporter.TestReporter):
             SA.Column('test', SA.Integer, index=True, nullable=False),
             SA.Column('failure', SA.Integer, index=True),
             SA.Column('build', SA.Integer, index=True, nullable=False),
-            SA.Column('buildbot_run_id', SA.String(16), index=True, nullable=True),
             SA.Column('end_time', SA.Integer, index=True, nullable=False),
             SA.Column('run_time', SA.Float, index=True, nullable=False),
             SA.Column('runner_id', SA.String(255), index=True, nullable=True),
@@ -193,7 +191,6 @@ class SQLReporter(test_reporter.TestReporter):
                 'test' : get_test_id(result['method']['module'], result['method']['class'], result['method']['name']),
                 'failure' : get_failure_id(result['exception_info']),
                 'build' : self.build_id,
-                'buildbot_run_id' : self.buildbot_run_id,
                 'end_time' : result['end_time'],
                 'run_time' : result['run_time'],
                 'runner_id' : result['runner_id'],


### PR DESCRIPTION
I haven't tried this on a buildbot yet but I'd like to get a feedback sooner than later.

The main motivation for the change is that it is pretty hard to query data for a single buildbot run. By having an extra column in the builds table we can enforce a unique buildbot run id. Uniqueness of the buildbot_run_id is enforced by buildbot (configuration).

Note: pull requests also adds the column to testresults, but that's probably a premature optimization for now. I'm going to remove it unless somethings it's okay/better to duplicate the information in tests results too. Otherwise there is already a pointer from testresults to build row.

The "pushplan" for this change is probably going to be something like the below:

ALTER TABLE builds ADD COLUMN buildbot_run_id varchar(16);
ALTER TABLE builds ADD INDEX (buildbot_run_id);
(and same thing for testresults table if we decide to keep it)
