### PR TITLE
_diff_message should use repr for any value other than str. (fixes #144)

### DIFF
--- a/test/assertions_test.py
+++ b/test/assertions_test.py
@@ -1,3 +1,4 @@
+#-*- coding: utf-8 -*-
 from __future__ import with_statement
 
 from testify import TestCase
@@ -62,6 +63,13 @@ class AssertEqualTestCase(TestCase):
         else:
             assert False, 'Expected `AssertionError`.'
 
+    def test_unicode_diff(self):
+        ascii_string = 'abc'
+        unicode_string = u'ü and some more'
+        def assert_with_unicode_msg():
+            assert_equal(unicode_string, ascii_string)
+        assertions.assert_raises_and_contains(AssertionError, 'abc', assert_with_unicode_msg)
+        assertions.assert_raises_and_contains(AssertionError, 'and some more', assert_with_unicode_msg)
 
 class MyException(Exception):
     pass

--- a/testify/assertions.py
+++ b/testify/assertions.py
@@ -225,8 +225,8 @@ def _diff_message(lhs, rhs):
 
     NOTE: Only works well for strings not containing newlines.
     """
-    lhs = repr(lhs) if not isinstance(lhs, basestring) else lhs
-    rhs = repr(rhs) if not isinstance(rhs, basestring) else rhs
+    lhs = repr(lhs) if not type(lhs) is str else lhs
+    rhs = repr(rhs) if not type(rhs) is str else rhs
 
     return 'Diff:\nl: %s\nr: %s' % stringdiffer.highlight(lhs, rhs)
 


### PR DESCRIPTION
assert statement (in Python 2) doesn't work with a unicode message string.
