### PR TITLE
Release 0.4.0 for class-level fixture ordering

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-testify (0.4.0) lucid; urgency=low
+
+  * Fix execution order of class level fixtures
+
+ -- Baris Metin <bmetin@yelp.com>  Wed, 03 Apr 2013 12:02:06 -0700
+
 python-testify (0.3.12) lucid; urgency=low
 
   * fix --violation-db-config option

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 setup(
     name="testify",
-    version="0.3.12",
+    version="0.4.0",
     provides=["testify"],
     author="Yelp",
     author_email="yelplabs@yelp.com",

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -25,7 +25,7 @@ The basic components of this system are:
         to kindly execute themselves.
 """
 __testify = 1
-__version__ = "0.3.12"
+__version__ = "0.4.0"
 
 import sys
 


### PR DESCRIPTION
Testify@master fixes the bugs related to execution order of class-level fixtures. The bug in class-level fixtures execution order would cause teardowns from class_setup_teardown and class_teardown methods to break in certain cases.

This is a "major" release bump as the fix changes the way testify handles class-level fixtures.
