### PR TITLE
Fix empty tests list

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -324,7 +324,7 @@ class TestCase(object):
                 continue
 
             # if there are any name overrides, only run the named methods
-            if self.__name_overrides is None or member.__name__ in self.__name_overrides:
+            if not self.__name_overrides or member.__name__ in self.__name_overrides:
                 yield member
 
     def run(self):


### PR DESCRIPTION
When executing test_program.TestProgram(['test', '--list-tests']) I was
getting an empty list, reason was self.__name_overrides was an empty
set != None
