### PR TITLE
Fix assert_(not_)?empty for tuples using .format

### DIFF
--- a/test/assertions_test.py
+++ b/test/assertions_test.py
@@ -348,6 +348,10 @@ class AssertDictSubsetTestCase(TestCase):
 
 class AssertEmptyTestCase(TestCase):
 
+    def test_passes_on_empty_tuple(self):
+        """Test that assert_empty passes on an empty tuple."""
+        assertions.assert_empty(())
+
     def test_passes_on_empty_list(self):
         """Test that assert_empty passes on an empty list."""
         assertions.assert_empty([])
@@ -359,6 +363,11 @@ class AssertEmptyTestCase(TestCase):
                 yield 0
 
         assertions.assert_empty(yield_nothing())
+
+    def test_fails_on_nonempty_tuple(self):
+        """Test that assert_empty fails on a nonempty tuple."""
+        with assertions.assert_raises(AssertionError):
+            assertions.assert_empty((0,))
 
     def test_fails_on_nonempty_list(self):
         """Test that assert_empty fails on a nonempty list."""
@@ -440,6 +449,10 @@ class AssertEmptyTestCase(TestCase):
 
 class AssertNotEmptyTestCase(TestCase):
 
+    def test_fails_on_empty_tuple(self):
+        with assertions.assert_raises(AssertionError):
+            assertions.assert_not_empty(())
+
     def test_fails_on_empty_list(self):
         """Test that assert_not_empty fails on an empty list."""
         with assertions.assert_raises(AssertionError):
@@ -453,6 +466,10 @@ class AssertNotEmptyTestCase(TestCase):
 
         with assertions.assert_raises(AssertionError):
             assertions.assert_not_empty(yield_nothing())
+
+    def test_passes_on_nonempty_tuple(self):
+        """Test that assert_not_empty passes on a nonempty tuple."""
+        assertions.assert_not_empty((0,))
 
     def test_passes_on_nonempty_list(self):
         """Test that assert_not_empty passes on a nonempty list."""

--- a/testify/assertions.py
+++ b/testify/assertions.py
@@ -387,7 +387,8 @@ def assert_empty(iterable, max_elements_to_print=None, message=None):
         except TypeError:
             max_elements_to_print = 10
 
-    message = message or "iterable %s was unexpectedly non-empty." % iterable
+    # Build the message *before* touching iterable since that might modify it.
+    message = message or "iterable {0} was unexpectedly non-empty.".format(iterable)
 
     # Get the first max_elements_to_print + 1 items from iterable, or just
     # the first item if max_elements_to_print is 0.  Trying to get an
@@ -419,9 +420,10 @@ def assert_not_empty(iterable, message=None):
     for value in iterable:
         break
     else:
-        # the else clause of a for loop is reached iff you break out of the loop
+        # The else clause of a for loop is reached iff you break out of the loop.
         raise AssertionError(message if message else
-            "iterable %s is unexpectedly empty" % iterable)
+            "iterable {0} is unexpectedly empty".format(iterable)
+        )
 
 
 def assert_length(sequence, expected, message=None):


### PR DESCRIPTION
Previously, the message for these was being generated using an expression like:
    message = '... %s ...' % iterable

Because the % operator interprets a tuple as a list of values to interpolate rather than a single value, using these assertions on tuples without exactly one value was raising exceptions about the format string. (Tuples with exactly one value just got a slightly incorrect error message.)

This commit fixes the problems and tests both assertions with both an empty and a non-empty tuple.
