### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyYAML>=3.0
+SQLAlchemy>=0.8
+mock>=1.0
+tornado>=2.4,<3.0


### PR DESCRIPTION
Testify requires a few modules before `make test` will run. In addition, Testify fails with tornado >= 3.0 because `IOLoop.running()` has been [removed](http://www.tornadoweb.org/en/stable/releases/v3.0.0.html?highlight=changes#tornado-ioloop).
