### PR TITLE
Fix traceback postmortem to not print one character per line.

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -612,7 +612,7 @@ class TestCase(object):
             if self.__debugger:
                 exc, val, tb = exc_info
                 print "\nDEBUGGER"
-                print "\n".join(result.format_exception_info())
+                print result.format_exception_info()
                 import ipdb
                 ipdb.post_mortem(tb)
             return False


### PR DESCRIPTION
Fixes https://github.com/Yelp/Testify/issues/188

I'm not really sure how to test this but here it is working:

```
$ python failing_test.py -d

DEBUGGER
Traceback (most recent call last):
  File "failing_test.py", line 6, in test_fail
    assert False
AssertionError

> /home/anthony/workspace/Testify/failing_test.py(6)test_fail()
      5     def test_fail(self):
----> 6         assert False
      7 

ipdb> q
fail: TestFailingTest.test_fail
Traceback (most recent call last):
  File "failing_test.py", line 6, in test_fail
    assert False
AssertionError

F
FAILED.  1 test / 1 case: 0 passed, 1 failed.  (Total test time 0.00s)

```
