### PR TITLE
assert that our doctests actually work as shown.

### DIFF
--- a/test/assertions_test.py
+++ b/test/assertions_test.py
@@ -11,6 +11,7 @@ from testify import assert_equal
 from testify import assert_not_reached
 from testify import assert_true
 from testify import assert_false
+from testify.contrib.doctestcase import DocTestCase
 
 
 class DiffMessageTestCase(TestCase):
@@ -832,6 +833,9 @@ class AssertWarnsTestCase(TestCase):
         assertions.assert_warns_such_that(three_warnings_caught,
                                           create_multiple_warnings, 3)
 
+
+class DocTest(DocTestCase):
+    module = assertions
 
 if __name__ == '__main__':
     run()

--- a/test/utils/stringdiffer_test.py
+++ b/test/utils/stringdiffer_test.py
@@ -1,6 +1,7 @@
 from testify import TestCase
 from testify import assert_equal
 from testify import run
+from testify.contrib.doctestcase import DocTestCase
 
 from testify.utils import stringdiffer
 
@@ -59,6 +60,10 @@ class HighlightStringTestCase(TestCase):
         diff = stringdiffer.highlight(lhs, rhs)
         assert_equal(expected_old, diff.old)
         assert_equal(expected_new, diff.new)
+
+
+class DocTest(DocTestCase):
+    module = stringdiffer
 
 
 if __name__ == '__main__':

--- a/test/utils/test_turtle.py
+++ b/test/utils/test_turtle.py
@@ -14,6 +14,7 @@
 
 
 from testify import *
+from testify.contrib.doctestcase import DocTestCase
 
 class TurtleTestCase(TestCase):
     @setup
@@ -50,3 +51,7 @@ class TurtleTestCase(TestCase):
         weapon = self.leonardo.weapon
         assert_equal(weapon, self.leonardo.weapon)
         assert weapon is self.leonardo.weapon
+
+
+class DocTest(DocTestCase):
+    module = turtle

--- a/testify/assertions.py
+++ b/testify/assertions.py
@@ -667,11 +667,15 @@ def assert_exactly_one(*args, **kwargs):
         True if desired conditions are satisfied. For example:
 
         >>> assert_exactly_one(True, False, truthy_fxn=bool) # Success
+        True
 
         >>> assert_exactly_one(0, None) # Success
+        0
 
         >>> assert_exactly_one(True, False)
-        AssertionError
+        Traceback (most recent call last):
+            ...
+        AssertionError: Expected exactly one True (got 2) args: (True, False)
 
     Returns:
         The argument that passes the truthy function

--- a/testify/utils/stringdiffer.py
+++ b/testify/utils/stringdiffer.py
@@ -97,7 +97,7 @@ class HighlightedDiff(tuple):
         return self[1]
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self.old, self.new)
+        return '%s(old=%r, new=%r)' % (self.__class__.__name__, self.old, self.new)
 
 
 def highlight(old, new):

--- a/testify/utils/turtle.py
+++ b/testify/utils/turtle.py
@@ -19,10 +19,10 @@ unknown (not predefined) attributed asked for. It is also callable, returning (o
 
 After a turtle is used, it can be inspected to find out what happened:
 
-  >>> leonardo = turtle.Turtle()
+  >>> leonardo = Turtle()
   >>> leonardo.color = "blue"
-  >>> leonardo.attack(weapon="katanas")
-  <testify.utils.turtle.Turtle object at 0x7fbd01e67dd0>
+  >>> leonardo.attack(weapon="katanas") #doctest:+ELLIPSIS
+  <testify.utils.turtle.Turtle object at 0x...>
 
   >>> len(leonardo.defend)
   0
@@ -31,7 +31,7 @@ After a turtle is used, it can be inspected to find out what happened:
   1
 
   >>> leonardo.attack.calls
-  [((), {'weapon': katanas})]
+  [((), {'weapon': 'katanas'})]
 
   >>> for args, kwargs in leonardo.attack:
   ...     print kwargs.get('weapon')


### PR DESCRIPTION
There are quite a few doctests in the code base already existing, but up to now we haven't assert that they work as shown. This branch adds those assertion, and in so doing adds eight tests to the test suite. A few small edits were necessary to make these "new" tests pass.

```
$ testify test -v --summary | grep DocTest
test.utils.stringdiffer_test DocTest.test_doc:highlight ... ok in 0.00s
test.utils.stringdiffer_test DocTest.test_doc:highlight_regions ... ok in 0.00s
test.utils.test_turtle DocTest.test_doc ... ok in 0.00s
test.assertions_test DocTest.test_doc:assert_exactly_one ... ok in 0.00s
test.assertions_test DocTest.test_doc:assert_raises ... ok in 0.00s
test.assertions_test DocTest.test_doc:assert_raises_such_that ... ok in 0.00s
test.assertions_test DocTest.test_doc:assert_warns ... ok in 0.00s
test.assertions_test DocTest.test_doc:assert_warns_such_that ... ok in 0.00s
```

I've also added a base class for DocMetaTestCase to simplify making doctest suites.
