### PR TITLE
clobber the warning filters less

### DIFF
--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -24,16 +24,17 @@ The basic components of this system are:
         a class which collects TestCase subclasses based on search criteria and asks them
         to kindly execute themselves.
 """
+from __future__ import absolute_import
 __testify = 1
 __version__ = "0.4.2"
 
 import sys
 
-from assertions import *
+from .assertions import *
 
-from errors import TestifyError
+from .errors import TestifyError
 
-from test_case import (
+from .test_case import (
                         MetaTestCase,
                         TestCase,
                         class_setup,
@@ -45,7 +46,13 @@ from test_case import (
                         suite,
                         let)
 
-from utils import turtle
+from .utils import turtle
 
-import test_program
-run = lambda: test_program.TestProgram(["__main__"] + sys.argv[1:])
+from .test_program import TestProgram
+run = lambda: TestProgram(["__main__"] + sys.argv[1:])
+
+
+# We want default warning behavior for DeprecationWarning's thrown within testify.
+# This gives consistent behavior (and makes our tests pass) under python2.7.
+import warnings
+warnings.filterwarnings('default', module='^testify(\.|$)', category=DeprecationWarning)

--- a/testify/assertions.py
+++ b/testify/assertions.py
@@ -22,11 +22,6 @@ import warnings
 from .utils import stringdiffer
 
 
-# DeprecationWarnings are off in Python >= 2.7, but we are a development
-# tool (and have tests that rely on warnings actually being thrown :))
-# so we want them on.
-warnings.simplefilter('default')
-
 __testify = 1
 
 


### PR DESCRIPTION
I've moved the filter to testify.**init** to make it less edge-casey, and restricted the filter to only match DeprecationWarnings raised within testify.
