### PR TITLE
Mrtyler no test impostors

### DIFF
--- a/test/test_case_test.py
+++ b/test/test_case_test.py
@@ -312,11 +312,6 @@ class CallbacksGetCalledTest(TestCase):
         ])
 
 
-class TestCaseKeepsReferenceToResultsForTestMethod(TestCase):
-    def test_reference_to_results(self):
-        assert self.test_result
-
-
 class FailingTeardownMethodsTest(TestCase):
 
     class ClassWithTwoFailingTeardownMethods(TestCase):
@@ -588,6 +583,11 @@ class ExceptionDuringTeardownTest(TestCase):
         assert_equal(expected, test_case.run_methods)
 
 
+class TestCaseKeepsReferenceToResultsForTestMethod(TestCase):
+    def test_reference_to_results(self):
+        assert self.test_result
+
+
 class NoAttributesNamedTest(TestCase):
     class FakeTestCase(TestCase):
         def test_your_might(self):
@@ -595,11 +595,6 @@ class NoAttributesNamedTest(TestCase):
 
     def test_attributes(self):
         test_case = self.FakeTestCase()
-
-        from pprint import pprint
-        pprint(sorted(dir(test_case)))
-        #import ipdb; ipdb.set_trace()
-
         expected_attributes = sorted([
             "test_result",     # Part of the public API (its name is unfortunate but e.g. Selenium relies on it)
             "test_your_might", # "Actual" test method in the test case

--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -136,7 +136,7 @@ class TestCase(object):
     def __init__(self, *args, **kwargs):
         super(TestCase, self).__init__()
 
-        self.test_fixtures = TestFixtures.discover_from(self)
+        self.__test_fixtures = TestFixtures.discover_from(self)
 
         self.__suites_include = kwargs.get('suites_include', set())
         self.__suites_exclude = kwargs.get('suites_exclude', set())
@@ -220,7 +220,7 @@ class TestCase(object):
         self.fire_event(self.EVENT_ON_RUN_TEST_CASE, test_case_result)
 
         self._stage = self.STAGE_CLASS_SETUP
-        with self.test_fixtures.class_context(
+        with self.__test_fixtures.class_context(
                 setup_callbacks=[
                     functools.partial(self.fire_event, self.EVENT_ON_RUN_CLASS_SETUP_METHOD),
                     functools.partial(self.fire_event, self.EVENT_ON_COMPLETE_CLASS_SETUP_METHOD),
@@ -310,7 +310,7 @@ class TestCase(object):
 
                 # first, run setup fixtures
                 self._stage = self.STAGE_SETUP
-                with self.test_fixtures.instance_context() as fixture_failures:
+                with self.__test_fixtures.instance_context() as fixture_failures:
                     # we haven't had any problems in class/instance setup, onward!
                     if not (fixture_failures + class_fixture_failures):
                         self._stage = self.STAGE_TEST_METHOD


### PR DESCRIPTION
`test_fixtures` should be private. yelp-main reminded us of this by having a test that manipulates the variable `test_fixtures` (see internal ticket #58770). Similar attributes use the `__` decorator so that's what I did.
