### PR TITLE
Allow testify to be run programmatically 

### DIFF
--- a/bin/testify
+++ b/bin/testify
@@ -22,4 +22,4 @@ if __name__ == "__main__":
     sys.path.insert(0, ".")
 
     # Start the program
-    test_program.TestProgram()
+    test_program.main()

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -52,8 +52,8 @@ from .test_fixtures import (
 
 from .utils import turtle
 
-from .test_program import TestProgram
-run = lambda: TestProgram(["__main__"] + sys.argv[1:])
+from .test_program import TestProgram, main
+run = main
 
 
 # We want default warning behavior for DeprecationWarning's thrown within testify.

--- a/testify/test_program.py
+++ b/testify/test_program.py
@@ -202,7 +202,9 @@ def _parse_test_runner_command_line_module_method_overrides(args):
 
     return test_path, module_method_overrides
 
+
 class TestProgram(object):
+
     def __init__(self, command_line_args=None):
         """Initialize and run the test with the given command_line_args
             command_line_args will be passed to parser.parse_args
@@ -219,8 +221,6 @@ class TestProgram(object):
             if hasattr(plugin_mod, "prepare_test_program"):
                 plugin_mod.prepare_test_program(self.other_opts, self)
 
-        self.run()
-
     def get_reporters(self, options, plugin_modules):
         reporters = []
         if options.disable_color:
@@ -234,6 +234,7 @@ class TestProgram(object):
         return reporters
 
     def run(self):
+        """Run testify, return True on success, False on failure."""
         self.setup_logging(self.other_opts)
 
         bucket_overrides = {}
@@ -277,10 +278,10 @@ class TestProgram(object):
 
         if self.runner_action == ACTION_LIST_SUITES:
             runner.list_suites()
-            sys.exit(0)
+            return True
         elif self.runner_action == ACTION_LIST_TESTS:
             runner.list_tests()
-            sys.exit(0)
+            return True
         elif self.runner_action == ACTION_RUN_TESTS:
             label_text = ""
             bucket_text = ""
@@ -296,8 +297,7 @@ class TestProgram(object):
                 if hasattr(plugin_mod, "prepare_test_runner"):
                     plugin_mod.prepare_test_runner(self.test_runner_args['options'], runner)
 
-            result = runner.run()
-            sys.exit(not result)
+            return runner.run()
 
     def setup_logging(self, options):
         root_logger = logging.getLogger()
@@ -326,5 +326,9 @@ class TestProgram(object):
                 logging.getLogger(logger_name).addHandler(handler)
 
 
+def main():
+    sys.exit(not TestProgram().run())
+
+
 if __name__ == "__main__":
-    TestProgram()
+    main()


### PR DESCRIPTION
Previously testify's main entry point was the constructor of the `TestProgram` class. This entry point also "returned" by calling `sys.exit()`. This makes it impossible to call from other code.

I've moved the main entry point to `test_program.main`. It still calls `sys.exit()` in main, but now you could call `TestProgram().run()` and handle the response.

My use case here is an acceptance test suite that sets up a sandbox.  I would like to be able to setup the sandbox in a context manager around testify. Something like this:

```
with sandbox():
    result = TestProgram().run()
```
