### PR TITLE
there's no reason to run instance fixtures if class setup has failed.

### DIFF
--- a/test/test_case_test.py
+++ b/test/test_case_test.py
@@ -386,13 +386,22 @@ class ExceptionDuringClassSetupTest(TestCase):
             super(ExceptionDuringClassSetupTest.FakeParentTestCase, self).__init__(*args, **kwargs)
 
         @class_setup
-        def parent_setup(self):
+        def parent_class_setup(self):
             self.run_methods.append("parent class_setup")
             raise Exception
 
         @class_teardown
-        def parent_teardown(self):
+        def parent_class_teardown(self):
             self.run_methods.append("parent class_teardown")
+
+        @setup
+        def parent_setup(self):
+            self.run_methods.append("parent setup")
+            raise Exception
+
+        @teardown
+        def parent_teardown(self):
+            self.run_methods.append("parent teardown")
 
         def test_parent(self):
             self.run_methods.append("parent test method")
@@ -400,12 +409,20 @@ class ExceptionDuringClassSetupTest(TestCase):
     class FakeChildTestCase(FakeParentTestCase):
 
         @class_setup
-        def child_setup(self):
+        def child_class_setup(self):
             self.run_methods.append("child class_setup")
 
         @class_teardown
-        def child_teardown(self):
+        def child_class_teardown(self):
             self.run_methods.append("child class_teardown")
+
+        @setup
+        def child_setup(self):
+            self.run_methods.append("child setup")
+
+        @teardown
+        def child_teardown(self):
+            self.run_methods.append("child teardown")
 
         def test_child(self):
             self.run_methods.append("child test method")

--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -297,17 +297,25 @@ class TestCase(object):
                 result.start()
                 self.__all_test_results.append(result)
 
+                # if class setup failed, this test has already failed.
+                self._stage = self.STAGE_CLASS_SETUP
+                for exc_info in class_fixture_failures:
+                    result.end_in_failure(exc_info)
+
+                if result.complete:
+                    continue
+
                 # first, run setup fixtures
                 self._stage = self.STAGE_SETUP
                 with self.__test_fixtures.instance_context() as fixture_failures:
                     # we haven't had any problems in class/instance setup, onward!
-                    if not (fixture_failures + class_fixture_failures):
+                    if not fixture_failures:
                         self._stage = self.STAGE_TEST_METHOD
                         result.record(test_method)
                     self._stage = self.STAGE_TEARDOWN
 
                 # maybe something broke during teardown -- record it
-                for exc_info in fixture_failures + class_fixture_failures:
+                for exc_info in fixture_failures:
                     result.end_in_failure(exc_info)
 
                 # if nothing's gone wrong, it's not about to start


### PR DESCRIPTION
Closes #220
