### PR TITLE
When stripping testify frames, make sure to include all non-testify frames.

### DIFF
--- a/testify/test_result.py
+++ b/testify/test_result.py
@@ -159,22 +159,30 @@ class TestResult(object):
         tb_formatter = fancy_tb_formatter if (pretty and fancy_tb_formatter) else plain_tb_formatter
 
         def is_relevant_tb_level(tb):
-            return tb.tb_frame.f_globals.has_key('__testify')
+            if tb.tb_frame.f_globals.has_key('__testify'):
+                # nobody *wants* to read testify
+                return False
+            else:
+                return True
 
         def count_relevant_tb_levels(tb):
+            # count up to the *innermost* relevant frame
             length = 0
-            while tb and not is_relevant_tb_level(tb):
+            relevant = 0
+            while tb:
                 length += 1
+                if is_relevant_tb_level(tb):
+                    relevant = length
                 tb = tb.tb_next
-            return length
+            return relevant
 
         def formatter(exctype, value, tb):
-            # Skip test runner traceback levels
-            while tb and is_relevant_tb_level(tb):
+            # Skip test runner traceback levels at the top.
+            while tb and not is_relevant_tb_level(tb):
                 tb = tb.tb_next
 
             if exctype is AssertionError:
-                # Skip testify.assertions traceback levels
+                # Skip testify.assertions traceback levels at the bottom.
                 length = count_relevant_tb_levels(tb)
                 return tb_formatter(exctype, value, tb, length)
             elif not tb:


### PR DESCRIPTION
Closes #177

Test failure for new test without my patch indicates the old formatter would just produce one frame of output.

```
$ testify test.test_result_test TestResultTestCase.test_frame_stripping -vv                                                     
test.test_result_test TestResultTestCase.test_frame_stripping ... fail: test.test_result_test TestResultTestCase.test_frame_stripping
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/mock.py", line 1190, in patched
    return func(*args, **keywargs)
  File "./test/test_result_test.py", line 51, in test_frame_stripping
    mock_format_exception.assert_called_with(AssertionError, 'wat', tb.tb_next.tb_next, 3)
  File "/usr/lib/pymodules/python2.6/mock.py", line 824, in assert_called_with
    raise AssertionError(msg)
AssertionError: Expected call: format_exception(<type 'exceptions.AssertionError'>, 'wat', <Mock name='mock.tb_next.tb_next.tb_next' id='38129104'>, 3
)
Actual call: format_exception(<type 'exceptions.AssertionError'>, 'wat', <Mock name='mock.tb_next.tb_next.tb_next' id='38129104'>, 1)

FAIL in 0.00s

FAILED.  1 tests / 1 cases: 0 passed, 1 failed.  (Total test time 0.00s)
```
