### PR TITLE
add catbox coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ before_install:
 
 install:
   - python setup.py install
+  - pip install catbox
 
-script: bin/testify --exclude catbox test
+script:
+  - bin/testify test


### PR DESCRIPTION
This branch currently fails due to setup.py issues in catbox, but there is a pending PR in the catbox project to fix that:

https://github.com/Pardus-Linux/catbox/pull/12

Once that is merged and posted on pypi, this branch will allow us to cover the catbox plugin tests.
