### PR TITLE
fix test filtering regression in more-fair-bucketing

### DIFF
--- a/testify/test_runner.py
+++ b/testify/test_runner.py
@@ -95,7 +95,11 @@ class TestRunner(object):
             return test_case
 
         def discover_tests():
-            return map(construct_test, test_discovery.discover(self.test_path_or_test_case))
+            return [
+                construct_test(test_case_class)
+                for test_case_class in test_discovery.discover(self.test_path_or_test_case)
+                if not self.module_method_overrides or test_case_class.__name__ in self.module_method_overrides
+            ]
 
         def discover_tests_by_buckets():
             # Sort by the test count, use the cmp_str as a fallback for determinism


### PR DESCRIPTION
The recent more-fair-bucketing branch caused testify to no longer filter test _cases_ when requested.
This fixes it.
