### PR TITLE
small tweaks to get tests passing under python -m testify.test_program test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="testify",

--- a/test/plugins/sql_reporter_test.py
+++ b/test/plugins/sql_reporter_test.py
@@ -141,7 +141,7 @@ class SQLReporterTestCase(SQLReporterBaseTestCase):
         assert_equal(failed_test['method_name'], 'test_fail')
         assert_equal(failed_test.traceback.split('\n'), [
             'Traceback (most recent call last):',
-            RegexMatcher('  File "\./test/plugins/sql_reporter_test\.py", line \d+, in test_fail'),
+            RegexMatcher('  File "(\./)?test/plugins/sql_reporter_test\.py", line \d+, in test_fail'),
             '    assert False',
             'AssertionError',
             '' # ends with newline
@@ -151,7 +151,7 @@ class SQLReporterTestCase(SQLReporterBaseTestCase):
         assert_equal(failed_test_2['method_name'], 'test_multiline')
         assert_equal(failed_test_2.traceback.split('\n'), [
             'Traceback (most recent call last):',
-            RegexMatcher('  File "\./test/plugins/sql_reporter_test\.py", line \d+, in test_multiline'),
+            RegexMatcher('  File "(\./)?test/plugins/sql_reporter_test\.py", line \d+, in test_multiline'),
             '    3""")',
             'Exception: I love lines:',
             '    1',

--- a/test/test_case_test.py
+++ b/test/test_case_test.py
@@ -349,15 +349,15 @@ class FailingTeardownMethodsTest(TestCase):
             [
                 'There were multiple errors in this test:',
                 'Traceback (most recent call last):',
-                RegexMatcher('  File "\./test/test_case_test\.py", line \d+, in test_method'),
+                RegexMatcher('  File "(\./)?test/test_case_test\.py", line \d+, in test_method'),
                 '    assert False',
                 'AssertionError',
                 'Traceback (most recent call last):',
-                RegexMatcher('  File "\./test/test_case_test\.py", line \d+, in first_teardown'),
+                RegexMatcher('  File "(\./)?test/test_case_test\.py", line \d+, in first_teardown'),
                 '    assert False',
                 'AssertionError',
                 'Traceback (most recent call last):',
-                RegexMatcher('  File "\./test/test_case_test\.py", line \d+, in second_teardown'),
+                RegexMatcher('  File "(\./)?test/test_case_test\.py", line \d+, in second_teardown'),
                 '    assert False',
                 'AssertionError',
                 '', # Ends with newline.


### PR DESCRIPTION
setuptools comes with pip, and everyone should have pip.
I don't believe we should ever use distutils, and we certainly don't test for that case.
