### PR TITLE
Bump to testify 0.5.5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+python-testify (0.5.5) lucid; urgency=low
+
+  * Fix failure reporting with only one slave in client/server model
+    (asottile, #240, #264, #274)
+  * Dynamically annotate unittests using catbox data (astephen2, #241)
+  * Fix regressions for windows (jareyes409, #245)
+  * Enable retries in sql reporter for SQL connection (bukzor, #249)
+  * Fix (run, test) ordering check in test_runner_server_test (asottile, #255)
+  * Fix flakey tests that depended on order (asottile, #257)
+  * Fix timing out test (asottile, #262)
+  * Standardize retry options (bukzor, #266)
+  * Fix flakey test with sql reporter (bukzor, #267)
+  * Use flake8 (astephen2, #271)
+
+ -- milki <milki@yelp.com>  Tue, 08 Jul 2014 14:47:36 -0700
+
 python-testify (0.5.4) lucid; urgency=low
 
   * Regression for runnig files directly (dnephin, #233)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="testify",
-    version="0.5.4",
+    version="0.5.5",
     provides=["testify"],
     author="Yelp",
     author_email="yelplabs@yelp.com",

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -26,7 +26,7 @@ The basic components of this system are:
 """
 from __future__ import absolute_import
 __testify = 1
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 import sys
 


### PR DESCRIPTION
- Fix failure reporting with only one slave in client/server model
  (asottile, #240, #264, #274)
- Dynamically annotate unittests using catbox data (astephen2, #241)
- Fix regressions for windows (jareyes409, #245)
- Enable retries in sql reporter for SQL connection (bukzor, #249)
- Fix (run, test) ordering check in test_runner_server_test (asottile, #255)
- Fix flakey tests that depended on order (asotille, #257)
- Fix timing out test (asottile, #262)
- Standardize retry options (bukzor, #266)
- Fix flakey test with sql reporter (bukzor, #267)
- Use flake8 (astephen2, #271)
