### PR TITLE
Version 0.6.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+python-testify (0.6.0) lucid; urgency=low
+
+  * Prevent pollution of __builtins__ in DocTestCase (asottile #297)
+  * Remove code coverage plugin, use coverage run -m testify.test_program
+    instead (asottile #301)
+  * Exit nonzero on ^C (asottile #302)
+  * Improve discovery logic (asottile #304)
+  * Support Python3 (asottile #303)
+
+ -- asottile <asottile@yelp.com>  Fri, 23 Jan 2015 11:02:00 -0800
+
 python-testify (0.5.7) lucid; urgency=low
 
   * Test Case Time Reporting Plugin (osarood, #295)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="testify",
-    version="0.5.7",
+    version="0.6.0",
     provides=["testify"],
     author="Yelp",
     author_email="yelplabs@yelp.com",
@@ -23,7 +23,7 @@ setup(
         "Intended Audience :: Developers",
         "Development Status :: 4 - Beta",
     ],
-    install_requires=['Mock', 'PyYaml', 'SQLAlchemy', 'Tornado', 'six'],
+    install_requires=['Mock', 'PyYaml', 'SQLAlchemy', 'Tornado', 'six>=1.7.3'],
     packages=["testify", "testify.contrib", "testify.utils", "testify.plugins"],
     scripts=['bin/testify'],
     long_description="""Testify - A Testing Framework

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -27,7 +27,7 @@ The basic components of this system are:
 # flake8: noqa
 from __future__ import absolute_import
 __testify = 1
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 from .assertions import *
 


### PR DESCRIPTION
  * Prevent pollution of __builtins__ in DocTestCase (asottile #297)
  * Remove code coverage plugin, use coverage run -m testify.test_program
    instead (asottile #301)
  * Exit nonzero on ^C (asottile #302)
  * Improve discovery logic (asottile #304)
  * Support Python3 (asottile #303)