### PR TITLE
More faster, and also try to fix that queue thing

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -117,6 +117,14 @@ class TestCase(six.with_metaclass(MetaTestCase, object)):
 
     log = class_logger.ClassLogger()
 
+    # For now, we still support the use of unittest-style assertions defined on
+    # the TestCase instance
+    for _name in dir(deprecated_assertions):
+        if _name.startswith(('assert', 'fail')):
+            locals()[_name] = classmethod(
+                getattr(deprecated_assertions, _name))
+    del _name
+
     def __init__(self, *args, **kwargs):
         super(TestCase, self).__init__()
 
@@ -136,17 +144,6 @@ class TestCase(six.with_metaclass(MetaTestCase, object)):
 
         self._stage = self.STAGE_UNSTARTED
 
-        # for now, we still support the use of unittest-style assertions defined on the TestCase instance
-        for name in dir(deprecated_assertions):
-            if name.startswith(('assert', 'fail')):
-                setattr(
-                    self,
-                    name,
-                    # http://stackoverflow.com/q/4364565
-                    getattr(deprecated_assertions, name).__get__(
-                        self, type(self),
-                    ),
-                )
         self.failure_limit = kwargs.pop('failure_limit', None)
         self.failure_count = 0
 


### PR DESCRIPTION
~10% faster.

Remaining `--list-tests` time breaks down as follows:

* 13% in `ensure_generator` (plus a bit more due to sorting), which I don't see how to improve without either changing our definition of a "method" or changing how fixtures are run, either of which would be fairly disruptive.
* 48% in `discover_from`, a decent chunk of which is spent in the `inspect` module determining whether something is a "real" function, which again would be disruptive to change.
* 41% doing imports, which is a different problem altogether.  (I don't believe this time overlaps with the above two, but it's hard to tell.)

That's just over 100% accounted for, so I don't think I can do much better from here.  :)