### PR TITLE
Run addfinalizer teardowns LIFO

### DIFF
--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -352,7 +352,7 @@ class TestCase(six.with_metaclass(MetaTestCase, object)):
 
         yield
 
-        for teardown in self.__extra_class_teardowns:
+        for teardown in reversed(self.__extra_class_teardowns):
             teardown()
 
     @test_fixtures.setup_teardown
@@ -361,7 +361,7 @@ class TestCase(six.with_metaclass(MetaTestCase, object)):
 
         yield
 
-        for teardown in self.__extra_test_teardowns:
+        for teardown in reversed(self.__extra_test_teardowns):
             teardown()
 
     def register_callback(self, event, callback):


### PR DESCRIPTION
Make sure that addfinalizer teardowns are run like a stack rather than a queue.