### PR TITLE
test discovery: yield results progressively

### DIFF
--- a/test/test_runner_test.py
+++ b/test/test_runner_test.py
@@ -116,14 +116,14 @@ class TestTestRunnerGetTestsForSuite(test_case.TestCase):
 
         instance = test_runner.TestRunner(mock.sentinel.test_class)
         ret = instance.get_tests_for_suite(mock.sentinel.selected_suite_name)
-        assert_equal(ret, [self.mock_test_method])
+        assert_equal(list(ret), [self.mock_test_method])
 
     def test_get_tests_for_suite_not_in_suite(self):
         self.in_suite_mock.return_value = False
 
         instance = test_runner.TestRunner(mock.sentinel.test_class)
         ret = instance.get_tests_for_suite(mock.sentinel.selected_suite_name)
-        assert_equal(ret, [])
+        assert_equal(list(ret), [])
 
 
 class TestTestRunnerPrintsTestNames(test_case.TestCase):

--- a/testify/test_reporter.py
+++ b/testify/test_reporter.py
@@ -27,10 +27,6 @@ class TestReporter(object):
         """
         self.options = options
 
-    def test_counts(self, test_case_count, test_method_count):
-        """Called after discovery finishes. May not be called by all test runners, e.g. TestRunnerClient."""
-        pass
-
     def test_start(self, result):
         """Called when a test method is being run. Gets passed a TestResult dict which should not be complete."""
         pass

--- a/testify/test_runner_json_replay.py
+++ b/testify/test_runner_json_replay.py
@@ -31,9 +31,6 @@ class TestRunnerJSONReplay(TestRunner):
             test_cases.add((result['method']['module'], result['method']['class'],))
             test_methods.add((result['method']['module'], result['method']['class'], result['method']['name'],))
 
-        for reporter in self.test_reporters:
-            reporter.test_counts(len(test_cases), len(test_methods))
-
         for result in self.results:
             for reporter in self.test_reporters:
                 reporter.test_start(result)


### PR DESCRIPTION
saves 20% wall time and 20% memory

In yelp main:

```
BEFORE:
69.66user 3.01system 1:21.89elapsed 88%CPU (0avgtext+0avgdata 5,806,912maxresident)k
224inputs+88outputs (1major+1,944,570minor)pagefaults 0swaps


69.84user 4.73system 1:23.84elapsed 88%CPU (0avgtext+0avgdata 5,801,632maxresident)k
0inputs+56outputs (1major+4,033,266minor)pagefaults 0swaps

68.77user 2.54system 1:20.60elapsed 88%CPU (0avgtext+0avgdata 5,938,432maxresident)k
0inputs+48outputs (1major+1,590,598minor)pagefaults 0swaps


AFTER:

64.93user 3.11system 1:08.89elapsed 98%CPU (0avgtext+0avgdata 4,779,600maxresident)k
0inputs+56outputs (3major+1,784,920minor)pagefaults 0swaps

63.14user 3.57system 1:07.30elapsed 99%CPU (0avgtext+0avgdata 4,779,792maxresident)k
0inputs+344outputs (1major+1,762,305minor)pagefaults 0swaps

64.71user 3.50system 1:08.77elapsed 99%CPU (0avgtext+0avgdata 4,779,600maxresident)k
8inputs+48outputs (1major+2,296,663minor)pagefaults 0swaps
```

Incidental changes:

- Removed the `test_count` reporting call back, which was used nowhere
- I believe we don't care about py26 or py33 anymore

- 