### PR TITLE
Remove ipython pretty formatting

### DIFF
--- a/test/test_result_test.py
+++ b/test/test_result_test.py
@@ -65,20 +65,6 @@ class TestResultTestCase(TestCase):
         mock_format_exception.assert_called_with(ValueError, value, tb, None)
         assert_equal(formatted, 'Traceback: ValueError\n')
 
-    @mock.patch('testify.test_result.fancy_tb_formatter')
-    def test_format_exception_info_assertion_pretty(self, mock_format):
-        value, tb = self._append_exc_info(AssertionError)
-        formatted = self.test_result.format_exception_info(pretty=True)
-        mock_format.assert_called_with(AssertionError, value, tb, 1)
-        assert_equal(formatted, mock_format.return_value)
-
-    @mock.patch('testify.test_result.fancy_tb_formatter')
-    def test_format_exception_info_error_pretty(self, mock_format):
-        value, tb = self._append_exc_info(ValueError)
-        formatted = self.test_result.format_exception_info(pretty=True)
-        mock_format.assert_called_with(ValueError, value, tb)
-        assert_equal(formatted, mock_format.return_value)
-
     @mock.patch('traceback.format_exception', wraps=fake_format_exception)
     def test_format_exception_info_multiple(self, mock_format_exception):
         class Error1(Exception):

--- a/testify/test_result.py
+++ b/testify/test_result.py
@@ -25,23 +25,6 @@ from testify.utils import inspection
 
 __testify = 1
 
-# If IPython is available, use it for fancy color traceback formatting
-try:
-    try:
-        # IPython >= 0.11
-        from IPython.core.ultratb import ListTB  # noqa
-    except ImportError:
-        # IPython < 0.11
-        from IPython.ultraTB import ListTB
-
-    list_tb = ListTB(color_scheme='Linux')
-
-    def fancy_tb_formatter(etype, value, tb, length=None):
-        tb = traceback.extract_tb(tb, limit=length)
-        return list_tb.text(etype, value, tb, context=0)
-except ImportError:
-    fancy_tb_formatter = None
-
 
 def plain_tb_formatter(etype, value, tb, length=None):
     # We want our formatters to return a string.
@@ -153,8 +136,6 @@ class TestResult(object):
         if not self.exception_infos:
             return None
 
-        tb_formatter = fancy_tb_formatter if (pretty and fancy_tb_formatter) else plain_tb_formatter
-
         def is_relevant_tb_level(tb):
             if '__testify' in tb.tb_frame.f_globals:
                 # nobody *wants* to read testify
@@ -181,11 +162,11 @@ class TestResult(object):
             if exctype is AssertionError:
                 # Skip testify.assertions traceback levels at the bottom.
                 length = count_relevant_tb_levels(tb)
-                return tb_formatter(exctype, value, tb, length)
+                return plain_tb_formatter(exctype, value, tb, length)
             elif not tb:
                 return "Exception: %r (%r)" % (exctype, value)
             else:
-                return tb_formatter(exctype, value, tb)
+                return plain_tb_formatter(exctype, value, tb)
 
         return self.__make_multi_error_message(formatter)
 


### PR DESCRIPTION
@ealter @bukzor 

This does weird things in the latest version of ipython and has caused several other bugs.  I don't think it's terribly important so let's remove it:
Resolves #284
Resolves #231