### PR TITLE
Remove IPython reference from debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,6 @@
 Source: python-testify
 Section: python
 Priority: optional
-Maintainer: James Brown <jbrown@yelp.com>
 Build-Depends: debhelper (>= 6.0.4), python-support (>= 0.5.3), cdbs (>= 0.4.51), python-central (>= 0.5.6)
 XS-Python-Version: >=2.5
 Standards-Version: 3.7.2
@@ -11,9 +10,8 @@ Architecture: all
 Homepage: http://github.com/Yelp/Testify
 XB-Python-Version: ${python:Versions}
 Depends: ${misc:Depends}, ${python:Depends}, python-pkg-resources (>= 0.6c8-0ubuntu2)
-Suggests: ipython (>= 0.8.1-2)
-Description: Testify is a replacement for Python's unittest module.  
-  It is modeled after unittest, and tests written for unittest will run under testify with a minimum 
+Description: Testify is a replacement for Python's unittest module.
+  It is modeled after unittest, and tests written for unittest will run under testify with a minimum
   of adjustments, but it has features above and beyond unittest:
     - class-level setup and teardown fixture methods which are run once each for an entire set of test methods.
     - a decorator-based approach for fixture methods, eliminating the need for super() calls.


### PR DESCRIPTION
@asottile removed IPython stuff in #336, we don't need to suggest it anymore.