### PR TITLE
Support for tags on test classes and methods

### DIFF
--- a/test/test_program_test.py
+++ b/test/test_program_test.py
@@ -95,9 +95,22 @@ class TestifyRunAcceptanceTestCase(TestCase):
             '--list-tests-format', 'json',
         ])
         assert_equal(output, '''\
-{"suites": [], "test": "testing_suite.example_test ExampleTestCase.test_one"}
-{"suites": [], "test": "testing_suite.example_test ExampleTestCase.test_two"}
-{"suites": [], "test": "testing_suite.example_test SecondTestCase.test_one"}''')
+{"suites": [], "tags": {}, "test": "testing_suite.example_test ExampleTestCase.test_one"}
+{"suites": [], "tags": {}, "test": "testing_suite.example_test ExampleTestCase.test_two"}
+{"suites": [], "tags": {}, "test": "testing_suite.example_test SecondTestCase.test_one"}''')
+
+    def test_list_tests_json_tags(self):
+        output = test_call([
+            sys.executable, '-m', 'testify.test_program',
+            '--list-tests', 'test.test_tags_test',
+            '--list-tests-format', 'json',
+        ])
+        assert_equal(output, '''\
+{"suites": [], "tags": {"key_1": ["a", "b", "f", "k"], "key_2": ["c"], "key_3": ["g"], "key_4": ["h"]}, "test": "test.test_tags_test TagsInheritedTestCase.test_extra_tags_on_method"}
+{"suites": [], "tags": {"key_1": ["a", "b", "f"], "key_2": ["c"], "key_3": ["g"], "key_4": ["h", "i"], "key_5": ["j"]}, "test": "test.test_tags_test TagsInheritedTestCase.test_new_method"}
+{"suites": [], "tags": {"key_1": ["a", "b", "f"], "key_2": ["c"], "key_3": ["g"], "key_4": ["h"]}, "test": "test.test_tags_test TagsInheritedTestCase.test_simple"}
+{"suites": [], "tags": {"key_1": ["a", "b", "d"], "key_2": ["c"], "key_3": ["e"]}, "test": "test.test_tags_test TagsTestCase.test_extra_tags_on_method"}
+{"suites": [], "tags": {"key_1": ["a", "b"], "key_2": ["c"]}, "test": "test.test_tags_test TagsTestCase.test_simple"}''')  # noqa
 
     def test_list_tests_json_suites(self):
         output = test_call([
@@ -106,21 +119,21 @@ class TestifyRunAcceptanceTestCase(TestCase):
             '--list-tests-format', 'json',
         ])
         assert_equal(output, '''\
-{"suites": ["class-level-suite", "disabled", "example", "module-level"], "test": "test.test_suites_test ListSuitesTestCase.test_also_disabled"}
-{"suites": ["class-level-suite", "crazy", "disabled", "example", "module-level"], "test": "test.test_suites_test ListSuitesTestCase.test_disabled"}
-{"suites": ["class-level-suite", "example", "module-level"], "test": "test.test_suites_test ListSuitesTestCase.<lambda>"}
-{"suites": ["assertion", "class-level-suite", "example", "module-level"], "test": "test.test_suites_test ListSuitesTestCase.test_list_suites"}
-{"suites": ["class-level-suite", "example", "module-level"], "test": "test.test_suites_test ListSuitesTestCase.test_not_disabled"}
-{"suites": ["class-level-suite", "disabled", "example", "module-level"], "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_also_disabled"}
-{"suites": ["class-level-suite", "crazy", "disabled", "example", "module-level"], "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_disabled"}
-{"suites": ["assertion", "class-level-suite", "example", "module-level"], "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_list_suites"}
-{"suites": ["class-level-suite", "example", "module-level"], "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_not_disabled"}
-{"suites": ["example", "module-level", "sub"], "test": "test.test_suites_test SubDecoratedTestCase.test_thing"}
-{"suites": ["example", "module-level", "sub", "super"], "test": "test.test_suites_test SubTestCase.test_thing"}
-{"suites": ["example", "module-level", "super"], "test": "test.test_suites_test SuperDecoratedTestCase.test_thing"}
-{"suites": ["example", "module-level", "super"], "test": "test.test_suites_test SuperTestCase.test_thing"}
-{"suites": ["module-level"], "test": "test.test_suites_test TestSuitesTestCase.test_subclass_suites_doesnt_affect_superclass_suites"}
-{"suites": ["module-level"], "test": "test.test_suites_test TestSuitesTestCase.test_suite_decorator_overrides_parent"}''')  # noqa
+{"suites": ["class-level-suite", "disabled", "example", "module-level"], "tags": {}, "test": "test.test_suites_test ListSuitesTestCase.test_also_disabled"}
+{"suites": ["class-level-suite", "crazy", "disabled", "example", "module-level"], "tags": {}, "test": "test.test_suites_test ListSuitesTestCase.test_disabled"}
+{"suites": ["class-level-suite", "example", "module-level"], "tags": {}, "test": "test.test_suites_test ListSuitesTestCase.<lambda>"}
+{"suites": ["assertion", "class-level-suite", "example", "module-level"], "tags": {}, "test": "test.test_suites_test ListSuitesTestCase.test_list_suites"}
+{"suites": ["class-level-suite", "example", "module-level"], "tags": {}, "test": "test.test_suites_test ListSuitesTestCase.test_not_disabled"}
+{"suites": ["class-level-suite", "disabled", "example", "module-level"], "tags": {}, "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_also_disabled"}
+{"suites": ["class-level-suite", "crazy", "disabled", "example", "module-level"], "tags": {}, "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_disabled"}
+{"suites": ["assertion", "class-level-suite", "example", "module-level"], "tags": {}, "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_list_suites"}
+{"suites": ["class-level-suite", "example", "module-level"], "tags": {}, "test": "test.test_suites_test TestifiedListSuitesUnittestCase.test_not_disabled"}
+{"suites": ["example", "module-level", "sub"], "tags": {}, "test": "test.test_suites_test SubDecoratedTestCase.test_thing"}
+{"suites": ["example", "module-level", "sub", "super"], "tags": {}, "test": "test.test_suites_test SubTestCase.test_thing"}
+{"suites": ["example", "module-level", "super"], "tags": {}, "test": "test.test_suites_test SuperDecoratedTestCase.test_thing"}
+{"suites": ["example", "module-level", "super"], "tags": {}, "test": "test.test_suites_test SuperTestCase.test_thing"}
+{"suites": ["module-level"], "tags": {}, "test": "test.test_suites_test TestSuitesTestCase.test_subclass_suites_doesnt_affect_superclass_suites"}
+{"suites": ["module-level"], "tags": {}, "test": "test.test_suites_test TestSuitesTestCase.test_suite_decorator_overrides_parent"}''')  # noqa
 
     def assert_rerun_discovery(self, format):
         output = test_call([

--- a/test/test_tags_test.py
+++ b/test/test_tags_test.py
@@ -14,14 +14,14 @@ class TagsTestCase(TestCase):
     def test_extra_tags_on_method(self):
         # First one will just be the class TagsTestCase:
         assert_equal(self.tags(), {
-            'key_1': set(['a', 'b']),
-            'key_2': set(['c'])
+            'key_1': {'a', 'b'},
+            'key_2': {'c'}
         })
         # Now also with this method:
         assert_equal(self.tags(self.test_extra_tags_on_method), {
-            'key_1': set(['a', 'b', 'd']),
-            'key_2': set(['c']),
-            'key_3': set(['e'])
+            'key_1': {'a', 'b', 'd'},
+            'key_2': {'c'},
+            'key_3': {'e'}
         })
 
 
@@ -35,18 +35,18 @@ class TagsInheritedTestCase(TagsTestCase):
     def test_new_method(self):
         # First one will just be the class, combination of TagsTestCase and TagsInheritedTestCase:
         assert_equal(self.tags(), {
-            'key_1': set(['a', 'b', 'f']),
-            'key_2': set(['c']),
-            'key_3': set(['g']),
-            'key_4': set(['h'])
+            'key_1': {'a', 'b', 'f'},
+            'key_2': {'c'},
+            'key_3': {'g'},
+            'key_4': {'h'}
         })
         # Now also with this method:
         assert_equal(self.tags(self.test_new_method), {
-            'key_1': set(['a', 'b', 'f']),
-            'key_2': set(['c']),
-            'key_3': set(['g']),
-            'key_4': set(['h', 'i']),
-            'key_5': set(['j'])
+            'key_1': {'a', 'b', 'f'},
+            'key_2': {'c'},
+            'key_3': {'g'},
+            'key_4': {'h', 'i'},
+            'key_5': {'j'}
         })
 
     @tag('key_1', 'k')
@@ -54,8 +54,8 @@ class TagsInheritedTestCase(TagsTestCase):
         # tags will be combination of TagsTestCase, TagsInheritedTestCase, and TagsInheritedTestCase.test_extra_tags_on_method
         # but not TagsTestCase.test_extra_tags_on_method
         assert_equal(self.tags(self.test_extra_tags_on_method), {
-            'key_1': set(['a', 'b', 'f', 'k']),
-            'key_2': set(['c']),
-            'key_3': set(['g']),
-            'key_4': set(['h'])
+            'key_1': {'a', 'b', 'f', 'k'},
+            'key_2': {'c'},
+            'key_3': {'g'},
+            'key_4': {'h'}
         })

--- a/test/test_tags_test.py
+++ b/test/test_tags_test.py
@@ -1,0 +1,61 @@
+from testify import TestCase, assert_equal, tag
+
+
+@tag('key_1', 'a')
+@tag('key_1', 'b')
+@tag('key_2', 'c')
+class TagsTestCase(TestCase):
+    def test_simple(self):
+        # Note this exists both in TagsTestCase and TagsInheritedTestCase
+        pass
+
+    @tag('key_1', 'd')
+    @tag('key_3', 'e')
+    def test_extra_tags_on_method(self):
+        # First one will just be the class TagsTestCase:
+        assert_equal(self.tags(), {
+            'key_1': set(['a', 'b']),
+            'key_2': set(['c'])
+        })
+        # Now also with this method:
+        assert_equal(self.tags(self.test_extra_tags_on_method), {
+            'key_1': set(['a', 'b', 'd']),
+            'key_2': set(['c']),
+            'key_3': set(['e'])
+        })
+
+
+@tag('key_1', 'f')
+@tag('key_3', 'g')
+@tag('key_4', 'h')
+class TagsInheritedTestCase(TagsTestCase):
+
+    @tag('key_4', 'i')
+    @tag('key_5', 'j')
+    def test_new_method(self):
+        # First one will just be the class, combination of TagsTestCase and TagsInheritedTestCase:
+        assert_equal(self.tags(), {
+            'key_1': set(['a', 'b', 'f']),
+            'key_2': set(['c']),
+            'key_3': set(['g']),
+            'key_4': set(['h'])
+        })
+        # Now also with this method:
+        assert_equal(self.tags(self.test_new_method), {
+            'key_1': set(['a', 'b', 'f']),
+            'key_2': set(['c']),
+            'key_3': set(['g']),
+            'key_4': set(['h', 'i']),
+            'key_5': set(['j'])
+        })
+
+    @tag('key_1', 'k')
+    def test_extra_tags_on_method(self):
+        # tags will be combination of TagsTestCase, TagsInheritedTestCase, and TagsInheritedTestCase.test_extra_tags_on_method
+        # but not TagsTestCase.test_extra_tags_on_method
+        assert_equal(self.tags(self.test_extra_tags_on_method), {
+            'key_1': set(['a', 'b', 'f', 'k']),
+            'key_2': set(['c']),
+            'key_3': set(['g']),
+            'key_4': set(['h'])
+        })

--- a/test/utils/dicts_test.py
+++ b/test/utils/dicts_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from testify import assert_equals
+from testify import TestCase
+from testify.utils import dicts
+
+
+class MergeDictsTest(TestCase):
+    def test_empty(self):
+        result = dicts.merge_dicts_of_sets()
+        assert_equals(result, {})
+
+    def test_one(self):
+        result = dicts.merge_dicts_of_sets({"a": set([1, 2])})
+        assert_equals(result, {"a": set([1, 2])})
+
+    def test_merge_unique(self):
+        result = dicts.merge_dicts_of_sets(
+            {"a": set([1, 2]), "b": set([5])},
+            {"a": set([1, 2, 3]), "b": set([5, 4])},
+            {"c": set([6]), "a": set()}
+        )
+        assert_equals(result, {'a': set([1, 2, 3]), 'c': set([6]), 'b': set([4, 5])})

--- a/test/utils/dicts_test.py
+++ b/test/utils/dicts_test.py
@@ -10,13 +10,13 @@ class MergeDictsTest(TestCase):
         assert_equals(result, {})
 
     def test_one(self):
-        result = dicts.merge_dicts_of_sets({"a": set([1, 2])})
-        assert_equals(result, {"a": set([1, 2])})
+        result = dicts.merge_dicts_of_sets({"a": {1, 2}})
+        assert_equals(result, {"a": {1, 2}})
 
     def test_merge_unique(self):
         result = dicts.merge_dicts_of_sets(
-            {"a": set([1, 2]), "b": set([5])},
-            {"a": set([1, 2, 3]), "b": set([5, 4])},
-            {"c": set([6]), "a": set()}
+            {"a": {1, 2}, "b": {5}},
+            {"a": {1, 2, 3}, "b": {5, 4}},
+            {"c": {6}, "a": set()}
         )
-        assert_equals(result, {'a': set([1, 2, 3]), 'c': set([6]), 'b': set([4, 5])})
+        assert_equals(result, {'a': {1, 2, 3}, 'c': {6}, 'b': {4, 5}})

--- a/testify/__init__.py
+++ b/testify/__init__.py
@@ -46,6 +46,7 @@ from .test_fixtures import (
     setup_teardown,
     class_setup_teardown,
     suite,
+    tag,
     let,
 )
 

--- a/testify/test_case.py
+++ b/testify/test_case.py
@@ -28,6 +28,7 @@ import six
 from testify import test_fixtures
 from testify.exceptions import Interruption
 from testify.utils import class_logger
+from testify.utils import dicts
 from testify.test_fixtures import DEPRECATED_FIXTURE_TYPE_MAP
 from testify.test_fixtures import TestFixtures
 from testify.test_fixtures import suite
@@ -235,6 +236,17 @@ class TestCase(six.with_metaclass(MetaTestCase, object)):
         if method is not None:
             suites |= getattr(method, '_suites', set())
         return suites
+
+    def tags(self, method=None):
+        """Returns the tags associated with this test case and, optionally, the
+        given method.  tags is a dictionary with the keys being a string, and
+        the values each being a set of strings."""
+        all_classes = inspect.getmro(type(self))
+        all_tag_dicts = [cls.__dict__['_tags'] for cls in all_classes if '_tags' in cls.__dict__]
+        if method and hasattr(method, '_tags'):
+            all_tag_dicts.append(method._tags)
+
+        return dicts.merge_dicts_of_sets(*all_tag_dicts)
 
     def results(self):
         """Available after calling `self.run()`."""

--- a/testify/test_fixtures.py
+++ b/testify/test_fixtures.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import contextlib
 import inspect
 import itertools
@@ -338,6 +339,24 @@ def suite(*args, **kwargs):
         return function
 
     return mark_test_with_suites
+
+
+def tag(tag_name, tag_value):
+    """Decorator to apply tags to a method or class.
+
+    A tag consists of a name and value, both strings. Testify consolidates all
+    of the tag values for each tag name. You can view tags by using the
+    TestCase.tags() method or via `testify --list-tests --list-tests-format json`
+    """
+    def mark_test_with_tag(function_or_class):
+        # check __dict__ instead of using hasattr() because we do not want to
+        # affect a parent class's attribute
+        if '_tags' not in function_or_class.__dict__:
+            function_or_class._tags = defaultdict(set)
+        function_or_class._tags[tag_name].add(tag_value)
+        return function_or_class
+
+    return mark_test_with_tag
 
 
 # unique id for fixtures

--- a/testify/test_runner.py
+++ b/testify/test_runner.py
@@ -212,10 +212,12 @@ class TestRunner(object):
                 print(name)
             elif format == 'json':
                 testcase = test.__self__
+                tags_sorted = dict((k, sorted(v)) for k, v in six.iteritems(testcase.tags(test)))
                 print(json.dumps(
                     dict(
                         test=name,
                         suites=sorted(testcase.suites(test)),
+                        tags=tags_sorted,
                     ),
                     sort_keys=True,
                 ))

--- a/testify/utils/dicts.py
+++ b/testify/utils/dicts.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+import itertools
+
+
+def merge_dicts_of_sets(*dicts):
+    """ Each value of each dictionary is expected to be a set.
+    Merge together the values within the sets of each key across all dictionaries.
+    returns a single dictionary with all the merged contents
+    """
+    merged = {}
+    for k in set(itertools.chain.from_iterable(d.keys() for d in dicts)):
+        merged[k] = set(itertools.chain.from_iterable(d.get(k, []) for d in dicts))
+    return merged

--- a/testify/utils/dicts.py
+++ b/testify/utils/dicts.py
@@ -3,7 +3,7 @@ import itertools
 
 
 def merge_dicts_of_sets(*dicts):
-    """ Each value of each dictionary is expected to be a set.
+    """Each value of each dictionary is expected to be a set.
     Merge together the values within the sets of each key across all dictionaries.
     returns a single dictionary with all the merged contents
     """


### PR DESCRIPTION
Tags can be applied to a method or class using the @tag(name, value) decorator.

A tag consists of a name and value, both strings. Testify consolidates all of the tag values for each tag name. You can view tags by using the TestCase.tags() method or via `testify --list-tests --list-tests-format json`
