### PR TITLE
Ignore comments in --rerun-test-file

### DIFF
--- a/testify/test_rerunner.py
+++ b/testify/test_rerunner.py
@@ -43,7 +43,7 @@ class TestRerunner(TestRunner):
         tests = [
             constructor(test)
             for test in tests.splitlines()
-            if test  # Skip blank lines
+            if test and not test.startswith('#')
         ]
 
         for class_path, tests in groupby(tests, lambda test: test[:2]):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py37
 
 [testenv]
 passenv = TERM


### PR DESCRIPTION
I find this useful when churning through a large list of tests in a single file to be able to quickly comment out tests I don't want to run at the moment.