### PR TITLE
logging level debug only if verbose

### DIFF
--- a/test/test_case_test.py
+++ b/test/test_case_test.py
@@ -378,30 +378,27 @@ class FailingTeardownMethodsTest(TestCase):
 
     def test_multiple_error_formatting(self):
         test_result = self.testcase.results()[0]
-        assert_equal(
-            test_result.format_exception_info().split('\n'),
-            [
-                'Traceback (most recent call last):',
-                RegexMatcher(r'  File "(\./)?test/test_case_test\.py", line \d+, in test_method'),
-                '    assert False',
-                'AssertionError',
-                '',
-                'During handling of the above exception, another exception occurred:',
-                '',
-                'Traceback (most recent call last):',
-                RegexMatcher(r'  File "(\./)?test/test_case_test\.py", line \d+, in first_teardown'),
-                '    assert False',
-                'AssertionError',
-                '',
-                'During handling of the above exception, another exception occurred:',
-                '',
-                'Traceback (most recent call last):',
-                RegexMatcher(r'  File "(\./)?test/test_case_test\.py", line \d+, in second_teardown'),
-                '    assert False',
-                'AssertionError',
-                '',  # Ends with newline.
-            ]
-        )
+        actual = test_result.format_exception_info()
+        expected_regex = r"""Traceback \(most recent call last\):
+  File \".*test\/test_case_test.py\", line \d+, in test_method
+    assert False
+AssertionError
+
+During handling of the above exception, another exception occurred:
+
+Traceback \(most recent call last\):
+  File \".*test\/test_case_test.py\", line \d+, in first_teardown
+    assert False
+AssertionError
+
+During handling of the above exception, another exception occurred:
+
+Traceback \(most recent call last\):
+  File \".*test\/test_case_test.py\", line \d+, in second_teardown
+    assert False
+AssertionError
+"""
+        assert_equal(RegexMatcher(expected_regex), actual)
 
 
 class RegexMatcher(object):

--- a/test/test_program_test.py
+++ b/test/test_program_test.py
@@ -1,9 +1,11 @@
+import logging
 import re
 import subprocess
 import sys
+from unittest.mock import MagicMock
 
 import mock
-from testify import setup_teardown, TestCase, test_program
+from testify import setup_teardown, TestCase, test_logger, test_program
 from testify.assertions import assert_equal, assert_raises, assert_in
 from optparse import OptionParser
 
@@ -199,3 +201,17 @@ PASSED.  7 tests / 6 cases: 7 passed, 0 failed.  (Total test time ${TIME})''')
             b'test.fails_two_tests FailsTwoTests.test2\n'
         )
         assert_in(b'FAILED.  1 test / 1 case: 0 passed, 1 failed.', stdout)
+
+
+class LoggingLevelTest(TestCase):
+    def test_default_logging_level(self):
+        options_mock = MagicMock(verbosity=test_logger.VERBOSITY_NORMAL)
+        with mock.patch("testify.test_program.logging") as logging_mock:
+            test_program.TestProgram().setup_logging(options_mock)
+        logging_mock.getLogger.return_value.setLevel.assert_not_called()
+
+    def test_varbose_logging_level(self):
+        options_mock = MagicMock(verbosity=test_logger.VERBOSITY_VERBOSE)
+        with mock.patch("testify.test_program.logging") as logging_mock:
+            test_program.TestProgram().setup_logging(options_mock)
+        logging_mock.getLogger.return_value.setLevel.assert_called_with(logging.DEBUG)

--- a/test/test_program_test.py
+++ b/test/test_program_test.py
@@ -205,13 +205,13 @@ PASSED.  7 tests / 6 cases: 7 passed, 0 failed.  (Total test time ${TIME})''')
 
 class LoggingLevelTest(TestCase):
     def test_default_logging_level(self):
-        options_mock = MagicMock(verbosity=test_logger.VERBOSITY_NORMAL)
+        _, _, _, options = test_program.parse_test_runner_command_line_args([], ["path"])
         with mock.patch("testify.test_program.logging") as logging_mock:
-            test_program.TestProgram().setup_logging(options_mock)
+            test_program.TestProgram().setup_logging(options)
         logging_mock.getLogger.return_value.setLevel.assert_not_called()
 
     def test_varbose_logging_level(self):
-        options_mock = MagicMock(verbosity=test_logger.VERBOSITY_VERBOSE)
+        _, _, _, options = test_program.parse_test_runner_command_line_args([], ["path", "--verbose"])
         with mock.patch("testify.test_program.logging") as logging_mock:
-            test_program.TestProgram().setup_logging(options_mock)
-        logging_mock.getLogger.return_value.setLevel.assert_called_with(logging.DEBUG)
+            test_program.TestProgram().setup_logging(options)
+        logging_mock.getLogger.return_value.setLevel.assert_called_with(logging_mock.DEBUG)

--- a/test/test_program_test.py
+++ b/test/test_program_test.py
@@ -1,11 +1,9 @@
-import logging
 import re
 import subprocess
 import sys
-from unittest.mock import MagicMock
 
 import mock
-from testify import setup_teardown, TestCase, test_logger, test_program
+from testify import setup_teardown, TestCase, test_program
 from testify.assertions import assert_equal, assert_raises, assert_in
 from optparse import OptionParser
 

--- a/testify/test_program.py
+++ b/testify/test_program.py
@@ -86,7 +86,13 @@ def default_parser():
 
     parser.set_defaults(verbosity=test_logger.VERBOSITY_NORMAL)
     parser.add_option("-s", "--silent", action="store_const", const=test_logger.VERBOSITY_SILENT, dest="verbosity")
-    parser.add_option("-v", "--verbose", action="store_const", const=test_logger.VERBOSITY_VERBOSE, dest="verbosity")
+    parser.add_option(
+        "-v", "--verbose",
+        action="store_const",
+        const=test_logger.VERBOSITY_VERBOSE,
+        dest="verbosity",
+        help="Outputs a more verbose output and sets the root logger level to debug."
+    )
     parser.add_option(
         '-d', '--ipdb', '--pdb',
         action="store_true",
@@ -317,7 +323,8 @@ class TestProgram(object):
 
     def setup_logging(self, options):
         root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
+        if options.verbosity == test_logger.VERBOSITY_VERBOSE:
+            root_logger.setLevel(logging.DEBUG)
 
         console = logging.StreamHandler()
         console.setFormatter(logging.Formatter("%(levelname)-8s %(message)s"))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py310
 
 [testenv]
 passenv = TERM


### PR DESCRIPTION
Set the root logger logging level to debug, only if `--verbose`.

I tested this locally, and it successfully suppressed the http library debug level logging.