### PR TITLE
fix under python 3.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Development Status :: 4 - Beta",
     ],
     install_requires=['mock', 'six>=1.7.3'],
+    python_requires='>=3.8',
     packages=["testify", "testify.contrib", "testify.utils", "testify.plugins"],
     scripts=['bin/testify'],
     long_description="""Testify - A Testing Framework

--- a/test/discovery_failure_test.py
+++ b/test/discovery_failure_test.py
@@ -35,8 +35,11 @@ class DiscoveryFailureTestCase(T.TestCase):
                 r'    Traceback \(most recent call last\):\n'
                 r'      File "[^"]+", line \d+, in discover\n'
                 r'        submod = __import__\(module_name, fromlist=\[str\(\'__trash\'\)\]\)\n'
+                r'(                 \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^'
+                r'\^\^\^\^\n)?'
                 r'      File "[^"]+", line \d+, in <module>\n'
                 r'        import non_existent_module  \# noqa: F401\n'
+                r'(        \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\n)?'
                 r'    (ModuleNotFoundError|ImportError): No module named \'?non_existent_module\'?\n'
             ),
         )
@@ -48,11 +51,14 @@ class DiscoveryFailureTestCase(T.TestCase):
         T.assert_equal(
             stderr,
             RegexMatcher(
-                r'Traceback \(most recent call last\):\n'
+                r'(Traceback \(most recent call last\):\n)?'
                 r'  File .+, line \d+, in discover\n'
                 r"    submod = __import__\(module_name, fromlist=\[str\(\'__trash\'\)\]\)\n"
+                r'(             \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^'
+                r'\^\^\n)?'
                 r'  File .+, line \d+, in <module>\n'
                 r'    import non_existent_module  \# noqa: F401\n'
+                r'(    \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\n)?'
                 r"(ModuleNotFoundError|ImportError): No module named '?non_existent_module'?\n"
             ),
         )

--- a/test/test_runner_test.py
+++ b/test/test_runner_test.py
@@ -1,10 +1,10 @@
-import imp
 import mock
 from testify import assert_equal
 from testify import setup
 from testify import setup_teardown
 from testify import test_case
 from testify import test_runner
+from types import ModuleType
 
 from .test_runner_subdir.inheriting_class import InheritingClass
 
@@ -59,7 +59,7 @@ class PluginTestCase(test_case.TestCase):
     """
     @setup
     def build_module(self):
-        self.our_module = imp.new_module("our_module")
+        self.our_module = ModuleType("our_module")
         setattr(self.our_module, "prepare_test_case", prepare_test_case)
         setattr(self.our_module, "run_test_case", run_test_case)
         setattr(self.our_module, "add_testcase_info", add_testcase_info)


### PR DESCRIPTION
- `imp` was removed in python 3.12, so this replaces usages. I also added a minimum python version of 3.8 as a result.
- The traceback format was changed in python 3.11, so I had to fix a test for that. 