### PR TITLE
add back sdist build to pypi action

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -37,4 +37,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python setup.py sdist
       - uses: pypa/gh-action-pypi-publish@v1.8.10


### PR DESCRIPTION
I removed this because I was copying from the docs, but it looks like this is still necessary.